### PR TITLE
Makefile based build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+version=$(shell git describe --abbrev=0 --tags | tr -d 'v')
+javasrc=$(shell find src)
+websrc=$(shell find web-app/public web-app/src) web-app/package.json
+webapptarget=src/main/resources/static/index.html
+
+target/poli-$(version).jar: $(javasrc) $(webapptarget)
+	mvn clean install -DskipTests
+
+web-app/node_modules: web-app/package.json
+	cd web-app && npm install
+
+web-app/build/index.html: $(websrc) web-app/node_modules
+	cd web-app && npm run build
+
+$(webapptarget): web-app/build/index.html
+	mkdir -p src/main/resources/static/
+	rm -rf src/main/resources/static/*
+	cp -r web-app/build/* src/main/resources/static/
+


### PR DESCRIPTION
Use `make` to build. Only those dependencies which have changed will be built.
For example `node_modules` will only be installed if package.json has been changed or if it is missing.
React app will only be built if web-app sources have been changed.

Fixes #23