### PR TITLE
Fix apiKey authority issue

### DIFF
--- a/src/main/java/com/shzlw/poli/filter/AuthFilter.java
+++ b/src/main/java/com/shzlw/poli/filter/AuthFilter.java
@@ -30,25 +30,23 @@ public class AuthFilter implements Filter {
         String path = httpRequest.getServletPath();
 
         if (path.startsWith("/ws/")) {
-            String sessionKey = getSessionKey(httpRequest);
+            String apiKey = httpRequest.getHeader(Constants.HTTP_HEADER_API_KEY);
             String sysRole = null;
             boolean isAuthByApiKey = false;
-            if (sessionKey != null) {
+            if (apiKey != null) {
+                User user = userService.getUserByApiKey(apiKey);
+                if (user != null) {
+                    httpRequest.setAttribute(Constants.HTTP_REQUEST_ATTR_USER, user);
+                    sysRole = user.getSysRole();
+                    isAuthByApiKey = true;
+                }
+            } else {
+                String sessionKey = getSessionKey(httpRequest);
                 User user = userService.getUserBySessionKey(sessionKey);
                 if (user != null) {
                     user.setSessionKey(sessionKey);
                     httpRequest.setAttribute(Constants.HTTP_REQUEST_ATTR_USER, user);
                     sysRole = user.getSysRole();
-                }
-            } else {
-                String apiKey = httpRequest.getHeader(Constants.HTTP_HEADER_API_KEY);
-                if (apiKey != null) {
-                    User user = userService.getUserByApiKey(apiKey);
-                    if (user != null) {
-                        httpRequest.setAttribute(Constants.HTTP_REQUEST_ATTR_USER, user);
-                        sysRole = user.getSysRole();
-                        isAuthByApiKey = true;
-                    }
                 }
             }
 

--- a/src/test/java/com/shzlw/poli/filter/AuthFilterTest.java
+++ b/src/test/java/com/shzlw/poli/filter/AuthFilterTest.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AuthFilterTest {
 
     @InjectMocks


### PR DESCRIPTION
if login poli system,The pskey property will be in the cookie,
Then visit :
/poli/workspace/report/fullscreen?$toReport=XXXX&apiKey=XXXX

The program will fetch the pskey value in the cookie and fetch the user object in the cache.
The user is valid for 5 minutes.If the user exists, the page displays normally.
If invalid, then null pointer, page blank! And it's always been that way.