### PR TITLE
index.html with relative paths to css and js files

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -2,6 +2,7 @@
   "name": "poli-web-app",
   "version": "0.11.0",
   "private": true,
+  "homepage": "./",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.17",
     "@fortawesome/free-regular-svg-icons": "^5.8.2",


### PR DESCRIPTION
Make poly more reverse proxy friendly: Use relative paths to load javascript and css so they are loaded from <domain>/poli/static instead <domain>/static.  So we don't need to publish /static folder.